### PR TITLE
Remove "required" asterisk from form labels.

### DIFF
--- a/themes/src/themes/parent-theme/collections/form.overrides
+++ b/themes/src/themes/parent-theme/collections/form.overrides
@@ -7,6 +7,16 @@
   font-family: @pageFont;
 }
 
+.ui.form {
+  .required.field {
+    label {
+      &:after {
+        content: '';
+      }
+    }
+  }
+}
+
 .ui.input {
 
   &.focus {

--- a/themes/src/themes/parent-theme/elements/input.overrides
+++ b/themes/src/themes/parent-theme/elements/input.overrides
@@ -7,7 +7,6 @@
 @borderFocus: inset 0 0 0 2px;
 
 .ui.input {
-
   &.focus {
     input {
       box-shadow: @borderFocus @primaryColor;


### PR DESCRIPTION
As above. We don't want to show the red required asterisk on form field labels.