### PR TITLE
Add in table icon spacing rules.

### DIFF
--- a/themes/src/themes/parent-theme/collections/table.overrides
+++ b/themes/src/themes/parent-theme/collections/table.overrides
@@ -91,6 +91,13 @@
         font-family: 'fontello';
         content: '\e801';
       }
+
+      &:after {
+        display: inline-block;
+        width: 16px;
+        height: 16px;
+        margin-right: 16px;
+      }
     }
   }
 }


### PR DESCRIPTION
Stops visible 'jump' when sorting a table column (because of the icon being made visible).

See: https://www.notion.so/florenceacademy/Stop-table-columns-jumping-when-sorting-602dc1a229e64018977967fe49b3fdd4