### PR TITLE
Watch & Recompile CSS file on changes / design system tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,15 @@
     "all:reset": "rm -rf node_modules/ && rm -rf yarn.lock && yarn install",
     "all:eslint": "eslint --ext .js ./docs ./themes .src/externals",
     "all:eslint:fix": "eslint --fix --ext .js ./docs ./themes .src/externals",
-    "docs:start:florence": "THEME=florence cross-env NODE_ENV=development gulp --series start:docs",
-    "docs:start:flexibank": "THEME=flexibank cross-env NODE_ENV=development gulp --series start:docs",
+    "docs:start:florence": "PORT=5001 THEME=florence cross-env NODE_ENV=development gulp --series start:docs",
+    "docs:start:flexibank": "PORT=5001 THEME=flexibank cross-env NODE_ENV=development gulp --series start:docs",
     "docs:build": "rm -rf docs/dist && cross-env NODE_ENV=development THEME=florence gulp build:docs",
     "docs:serve": "serve docs/dist",
     "docs:deploy:docs": "gulp deploy:docs",
     "themes:build": "rm -rf themes/dist && node themes/config/build.js",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "start:all": "npm-run-all --parallel themes:build docs:start:florence start"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",
@@ -76,6 +77,7 @@
     "leven": "^2.1.0",
     "lodash": "^4.17.11",
     "moment": "^2.22.2",
+    "npm-run-all": "^4.1.5",
     "null-loader": "^0.1.1",
     "postcss-flexbugs-fixes": "^4.1.0",
     "postcss-loader": "^3.0.0",
@@ -108,6 +110,7 @@
   },
   "dependencies": {
     "express": "^4.17.1",
-    "font-awesome": "^4.7.0"
+    "font-awesome": "^4.7.0",
+    "gulp-run": "^1.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "themes:build": "rm -rf themes/dist && node themes/config/build.js",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "start:all": "npm-run-all --parallel themes:build docs:start:florence start"
+    "start:florence": "npm-run-all --parallel themes:build docs:start:florence start",
+    "start:flexibank": "npm-run-all --parallel themes:build docs:start:flexibank start"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",

--- a/themes/src/themes/parent-theme/elements/button.overrides
+++ b/themes/src/themes/parent-theme/elements/button.overrides
@@ -5,7 +5,7 @@
 @hoverTranslate: translateY(-2px);
 @shadow: 0 @relative5px @relative10px -5px;
 @hoverShadow: 0 @relative5px @relative12px -3px;
-@transition: transform .2s ease;
+@transition: transform 0.2s ease;
 
 .ui.button {
   border-radius: @borderRadius;
@@ -36,7 +36,9 @@
   &.primary {
     box-shadow: @shadow @lightPrimaryColor;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @lightPrimaryColor;
     }
   }
@@ -47,7 +49,9 @@
     border: @invertedBorderSize solid @primaryColor;
     color: @darkGrey;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @darkWhite;
       color: @darkGrey;
     }
@@ -63,22 +67,28 @@
   &.yellow {
     box-shadow: @shadow @yellow;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @lightYellow;
     }
   }
-  
+
   &.olive {
     box-shadow: @shadow @olive;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @lightOlive;
     }
   }
 
   &.brown {
     box-shadow: @shadow @brown;
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @lightBrown;
     }
   }
@@ -86,7 +96,9 @@
   &.violet {
     box-shadow: @shadow @violet;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @lightViolet;
     }
   }
@@ -94,7 +106,9 @@
   &.grey {
     box-shadow: @shadow @grey;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @offWhite;
     }
   }
@@ -102,7 +116,9 @@
   &.orange {
     box-shadow: @shadow @orange;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @lightOrange;
     }
   }
@@ -110,7 +126,9 @@
   &.green {
     box-shadow: @shadow @green;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @lightGreen;
     }
   }
@@ -118,7 +136,9 @@
   &.teal {
     box-shadow: @shadow @teal;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @lightTeal;
     }
   }
@@ -126,7 +146,9 @@
   &.blue {
     box-shadow: @shadow @blue;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @lightBlue;
     }
   }
@@ -134,7 +156,9 @@
   &.purple {
     box-shadow: @shadow @purple;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @lightPurple;
     }
   }
@@ -142,7 +166,9 @@
   &.pink {
     box-shadow: @shadow @pink;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @lightPink;
     }
   }
@@ -150,7 +176,9 @@
   &.red {
     box-shadow: @shadow @red;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @lightRed;
     }
   }
@@ -158,7 +186,9 @@
   &.black {
     box-shadow: @shadow @black;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @offWhite;
     }
   }
@@ -166,7 +196,9 @@
   &.positive {
     box-shadow: @shadow @positiveColor;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @positiveColor;
     }
   }
@@ -174,7 +206,9 @@
   &.negative {
     box-shadow: @shadow @negativeColor;
 
-    &:visited, &:focus, &:hover {
+    &:visited,
+    &:focus,
+    &:hover {
       box-shadow: @hoverShadow @negativeColor;
     }
   }
@@ -192,7 +226,8 @@
     transform: translateY(0);
   }
 
-  &:visited, &:focus {
+  &:visited,
+  &:focus {
     color: @white;
     background: @primaryColor;
   }
@@ -209,7 +244,7 @@
   }
 
   &.secondary.icon.labeled {
-    padding: @8px; 
+    padding: @8px;
   }
 }
 
@@ -218,13 +253,15 @@
 .ui.dropdown.button,
 .ui.dropdown.search.button,
 .ui.attached.buttons,
-.ui.right.labeled.button
-.ui.attached.buttons,
+.ui.right.labeled.button .ui.attached.buttons,
 .ui.action.input {
-  .ui.button, .ui.labeled.button {
+  .ui.button,
+  .ui.labeled.button {
     box-shadow: none;
 
-    &:hover, &:visited, &:active {
+    &:hover,
+    &:visited,
+    &:active {
       transform: translateY(0);
     }
   }
@@ -234,7 +271,9 @@
 .ui.attached.right.button {
   box-shadow: none;
 
-  &:hover, &:visited, &:active {
+  &:hover,
+  &:visited,
+  &:active {
     transform: translateY(0);
   }
 }
@@ -260,10 +299,9 @@
 
 .ui.breadcrumb.buttons > .ui.disabled.button {
   background: @primaryBackground;
-  opacity: 1!important;
+  opacity: 1 !important;
 
   &:hover {
     background: @primaryBackground;
   }
 }
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -4842,6 +4842,11 @@ clone-stats@^1.0.0:
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-1.0.0.tgz#b3782dff8bb5474e18b9b6bf0fdfe782f8777680"
   integrity sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=
 
+clone@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-0.2.0.tgz#c6126a90ad4f72dbf5acdb243cc37724fe93fc1f"
+  integrity sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=
+
 clone@^1.0.0, clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -7998,7 +8003,17 @@ gulp-load-plugins@^1.5.0:
     micromatch "^3.1.10"
     resolve "^1.1.7"
 
-gulp-util@^3.0.8:
+gulp-run@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/gulp-run/-/gulp-run-1.7.1.tgz#e17c0acb7c30b6e2aeee23c04442a96c0caceffa"
+  integrity sha1-4XwKy3wwtuKu7iPAREKpbAys7/o=
+  dependencies:
+    gulp-util "^3.0.0"
+    lodash.defaults "^4.0.1"
+    lodash.template "^4.0.2"
+    vinyl "^0.4.6"
+
+gulp-util@^3.0.0, gulp-util@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   integrity sha1-AFTh50RQLifATBh8PsxQXdVLu08=
@@ -9662,6 +9677,16 @@ load-json-file@^2.0.0:
     pify "^2.0.0"
     strip-bom "^3.0.0"
 
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
+
 loader-fs-cache@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz#54cedf6b727e1779fd8f01205f05f6e88706f086"
@@ -9777,6 +9802,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.defaults@^4.0.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
+
 lodash.escape@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-3.2.0.tgz#995ee0dc18c1b48cc92effae71a10aab5b487698"
@@ -9838,7 +9868,7 @@ lodash.template@^3.0.0:
     lodash.restparam "^3.0.0"
     lodash.templatesettings "^3.0.0"
 
-lodash.template@^4.5.0:
+lodash.template@^4.0.2, lodash.template@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
   integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
@@ -10147,6 +10177,11 @@ memory-fs@^0.5.0:
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
+
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
+  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
 
 meow@^3.3.0:
   version "3.7.0"
@@ -10735,6 +10770,21 @@ npm-packlist@^1.1.6:
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
+
+npm-run-all@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
+  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    memorystream "^0.3.1"
+    minimatch "^3.0.4"
+    pidtree "^0.3.0"
+    read-pkg "^3.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -11402,6 +11452,11 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+pidtree@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.0.tgz#f6fada10fccc9f99bf50e90d0b23d72c9ebc2e6b"
+  integrity sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -13014,6 +13069,15 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
+
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
@@ -13951,7 +14015,7 @@ shell-quote@1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
-shell-quote@1.7.2:
+shell-quote@1.7.2, shell-quote@^1.6.1:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
@@ -15639,6 +15703,14 @@ vinyl-sourcemap@^1.1.0:
     now-and-later "^2.0.0"
     remove-bom-buffer "^3.0.0"
     vinyl "^2.0.0"
+
+vinyl@^0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-0.4.6.tgz#2f356c87a550a255461f36bbeb2a5ba8bf784847"
+  integrity sha1-LzVsh6VQolVGHza76ypbqL94SEc=
+  dependencies:
+    clone "^0.2.0"
+    clone-stats "^0.0.1"
 
 vinyl@^0.5.0:
   version "0.5.3"


### PR DESCRIPTION
- Adds `npm-run-all` package to be able to run multiple npm/yarn scripts in parallel.
- Adds `gulp-run` package to be able to run npm/yarn scripts from within a gulp file.
- Created new `build:css` task that recompiles the main `sui-florence.css` theme file whenever any .less/.css changes are made within the semantic theme.
- Created new gulp watcher task that actually initiates the CSS recompile task on file changes.
- Needed to configure `PORT 5001` to serve the semantic docs as `5000` is now reserved to run the node server which serves the `sui-florence.css` file to Rails.