### PR TITLE
Don't import react-datepicker css via Semantic.

### DIFF
--- a/themes/src/themes/parent-theme/external/react-datepicker.overrides
+++ b/themes/src/themes/parent-theme/external/react-datepicker.overrides
@@ -1,1 +1,4 @@
-@import (less) '../../../../../node_modules/react-datepicker/dist/react-datepicker.css';
+// Importing the CSS file for this React Component from within the design system like this
+// does not work. Please see: app/javascript/components/references/form/stepTwo for an example
+// of how to import it correctly.
+// @import (less) '../../../../../node_modules/react-datepicker/dist/react-datepicker.css';


### PR DESCRIPTION
As above - you need to import the CSS file from the package manually when you use it.

All sorts of weird CSS issues occur when you try and use it 'out of the box' with the styles being imported through Semantic UI.