### PR TITLE
Change standard table override theme to fit with the new table designs

### DIFF
--- a/themes/src/themes/parent-theme/collections/table.overrides
+++ b/themes/src/themes/parent-theme/collections/table.overrides
@@ -1,7 +1,5 @@
 .ui.table {
   position: relative;
-  padding-left: 85px;
-  padding-right: 85px;
   border: none !important;
   border-collapse: separate;
   border-spacing: 0 8px;
@@ -20,7 +18,7 @@
       background: #1d2630;
     }
 
-     tr:first-child>th:only-child {
+    tr:first-child>th:only-child {
       border-radius: 8px !important;
     }
 
@@ -33,9 +31,10 @@
     }
   }
 
-   tbody tr {
+  tbody tr {
     background-color: #f6f7f9;
     cursor: pointer;
+
     &:hover {
       background: #f5f2fd;
     }
@@ -48,6 +47,13 @@
     tr:first-child > th:last-child:not {
       border-top-right-radius: 8px;
       border-bottom-right-radius: 8px;
+    }
+
+    td {
+      font-size: 16px;
+      padding-top: 8px;
+      padding-bottom: 8px;
+      border: 0 none;
     }
   }
 
@@ -63,9 +69,9 @@
 
   td.active {
     box-shadow: none;
-    background: none;
+    background: none !important;
     font-weight: 600;
-    color: #3d5066;
+    color: #3d5066 !important;
   }
 
   tfoot th {
@@ -73,8 +79,8 @@
   }
 
    &.striped {
-      tr:nth-child(2n),
-      tbody tr:nth-child(2n) {
+    > tr:nth-child(2n),
+    tbody tr:nth-child(2n) {
       background-color: #f6f7f9;
     }
   }
@@ -83,11 +89,11 @@
 .ui.selectable.table {
   tbody {
     tr:hover {
-      background: #f5f2fd;
+      background: #f5f2fd !important;
 
       td {
         &.active {
-          background: none;
+          background: none !important;
         }
       }
     }

--- a/themes/src/themes/parent-theme/collections/table.overrides
+++ b/themes/src/themes/parent-theme/collections/table.overrides
@@ -1,51 +1,80 @@
 .ui.table {
-  border: 1px solid #f6f7f9;
+  position: relative;
+  padding-left: 85px;
+  padding-right: 85px;
+  border: none !important;
+  border-collapse: separate;
+  border-spacing: 0 8px;
+  margin-top: 40px;
 
   thead {
     background: #1d2630;
     color: @white;
 
-    th {
-      background: #1d2630;
+    th {  
       font-size: 16px;
       font-weight: 600;
       padding-top: 16px;
       padding-bottom: 16px;
       color: @white;
+      background: #1d2630;
+    }
+
+     tr:first-child>th:only-child {
+      border-radius: 8px !important;
+    }
+
+    tr:first-child>th:first-child {
+      border-radius: 8px 0 0 8px;
+    }
+
+    tr:first-child>th:last-child {
+      border-radius: 0 8px 8px 0;
     }
   }
 
-  tbody {
-    tr {
-      td.selectable:hover {
-        background: #f5f2fd;
-      }
+   tbody tr {
+    background-color: #f6f7f9;
+    cursor: pointer;
+    &:hover {
+      background: #f5f2fd;
+    }
+
+    tr:first-child > th:first-child {
+      border-top-left-radius: 8px;
+      border-bottom-left-radius: 8px;
+    }
+
+    tr:first-child > th:last-child:not {
+      border-top-right-radius: 8px;
+      border-bottom-right-radius: 8px;
     }
   }
 
-  tr {
-    td {
-      border-top: 0 none;
-    }
+  td:first-child {
+    border-top-left-radius: 8px;
+    border-bottom-left-radius: 8px;
   }
 
-  td {
-    font-size: 16px;
-    padding-top: 16px;
-    padding-bottom: 16px;
+  td:last-child {
+    border-top-right-radius: 8px;
+    border-bottom-right-radius: 8px;
+  }
+
+  td.active {
+    box-shadow: none;
+    background: none;
+    font-weight: 600;
     color: #3d5066;
-
-    &.active {
-      box-shadow: none;
-      background: none !important;
-      font-weight: 600;
-      color: #3d5066 !important;
-    }
   }
 
-  &.striped {
-    > tr:nth-child(2n),
-    tbody tr:nth-child(2n) {
+  tfoot th {
+    background: none;
+  }
+
+   &.striped {
+      tr:nth-child(2n),
+      tbody tr:nth-child(2n) {
       background-color: #f6f7f9;
     }
   }
@@ -54,11 +83,11 @@
 .ui.selectable.table {
   tbody {
     tr:hover {
-      background: #f5f2fd !important;
+      background: #f5f2fd;
 
       td {
         &.active {
-          background: none !important;
+          background: none;
         }
       }
     }
@@ -102,4 +131,16 @@
       }
     }
   }
+}
+
+.ui.ribbon.label:after {
+  border-width: 0 1.2em 0.4em 0;
+}
+
+.ui.celled.table tr td, .ui.celled.table tr th {
+  border: none;
+}
+
+.ui.structured.celled.table tr td, .ui.celled.table tr th {
+  border: none;
 }


### PR DESCRIPTION
Update the override table theme styling for standard table to fit with the new table designs on desktop:

<img width="1518" alt="Screenshot 2020-09-21 at 14 34 32" src="https://user-images.githubusercontent.com/13727615/93773885-80e30e00-fc18-11ea-850d-788098f0a76e.png">
