### PR TITLE
Modal - Add Blur Effect

### DIFF
--- a/themes/src/themes/parent-theme/modules/modal.overrides
+++ b/themes/src/themes/parent-theme/modules/modal.overrides
@@ -25,6 +25,8 @@
 }
 
 .modals.dimmer[class*='top aligned'] {
+  backdrop-filter: blur(3px);
+
   .modal {
     margin-top: -100px;
   }


### PR DESCRIPTION
As the title suggests... adds the `backface-filter` property (not supported by Firefox or IE) to provide a blur effect to the existing semi-transparent "dimmer"

Example:

<img width="1792" alt="Blur" src="https://user-images.githubusercontent.com/525908/96625741-7a72af80-1306-11eb-923f-ddf756d424e1.png">
