### PR TITLE
Bug: Checkbox toggle/slider variation incorrect styling

### DIFF
--- a/themes/src/themes/parent-theme/modules/checkbox.overrides
+++ b/themes/src/themes/parent-theme/modules/checkbox.overrides
@@ -1,4 +1,4 @@
-.ui.checkbox {
+.ui.checkbox:not(.toggle) {
   input[type=checkbox] {
     width: @checkboxSize;
     height: @checkboxSize;


### PR DESCRIPTION
- When styling the `<Checkbox />` component previously, I did not scope the changes to only affect the core checkbox component. The changes therefore broke the toggle/slider variation of the component.

**Before**
![Untitled](https://user-images.githubusercontent.com/525908/99248355-376e0400-2800-11eb-9f7f-ba1e4dbbaa0c.png)

**With Fix Applied**
<img width="1792" alt="Screenshot 2020-11-16 at 11 35 12" src="https://user-images.githubusercontent.com/525908/99248372-3e951200-2800-11eb-9655-59d01a3a4c4b.png">

Notion Bug
https://www.notion.so/florenceacademy/The-toggle-on-shift-posting-changes-size-9a3b23210e3f4472a5910f217d8c280d