### PR TITLE
Cross browser bug fixes (modal & table table border radius)

### DIFF
--- a/themes/src/themes/parent-theme/collections/table.overrides
+++ b/themes/src/themes/parent-theme/collections/table.overrides
@@ -8,7 +8,9 @@
   thead {
     background: #1d2630;
     color: @white;
-    
+    background: none;
+    border-radius: 8px;
+
     th {
       font-size: 16px;
       font-weight: 500;
@@ -33,6 +35,7 @@
 
   tbody tr {
     background-color: #f6f7f9;
+    border-radius: 8px;
     cursor: pointer;
 
     &:hover {
@@ -106,6 +109,7 @@
       color: @white;
 
       &:hover {
+        background: #1d2630;
         color: @white;
       }
 

--- a/themes/src/themes/parent-theme/modules/modal.overrides
+++ b/themes/src/themes/parent-theme/modules/modal.overrides
@@ -24,6 +24,11 @@
   margin-top: -100px !important;
 }
 
+// Targets IE 11 in order to fix centre alignment modal issue
+@media all and (-ms-high-contrast:none) {
+  *::-ms-backdrop, .ui.legacy.modal { margin-top: -200px !important; }
+}
+
 .modals.dimmer[class*='top aligned'] {
   backdrop-filter: blur(3px);
 


### PR DESCRIPTION
### Change Summary:
1. Fixes and issue whereby the Grace Period modal becomes partially cut off in certain screen sizes when on IE 11. 

**Before:**
React before...
<img width="2126" alt="React before" src="https://user-images.githubusercontent.com/13727615/106923184-bab73b80-6705-11eb-8056-6406b28d494a.png">

Rails before...
<img width="2128" alt="Rails before" src="https://user-images.githubusercontent.com/13727615/106923210-c0ad1c80-6705-11eb-8304-fe949ab6754c.png">

**After - React and Rails:**
React after ...
<img width="2130" alt="React after" src="https://user-images.githubusercontent.com/13727615/106923352-e20e0880-6705-11eb-85fa-6b3310807c5c.png">

Rails after...
<img width="2128" alt="Rails after" src="https://user-images.githubusercontent.com/13727615/106923362-e3d7cc00-6705-11eb-9baa-5bf243ba6b98.png">

2. Half fixes another issue in the Firefox browser where the border radius isn't being applied to table rows (🤷‍♂️) - I only managed to apply the border radius to the black table header row but not the normal grey rows

**Before:**
![image](https://user-images.githubusercontent.com/13727615/106923738-4c26ad80-6706-11eb-96c7-1e3ea3800efb.png)

**After:**
<img width="1878" alt="Screenshot 2021-02-04 at 16 34 05" src="https://user-images.githubusercontent.com/13727615/106924298-d7a03e80-6706-11eb-9362-f06daf1b8f95.png">