### PR TITLE
Add color overrides for violet & olive for label component

### DIFF
--- a/themes/src/themes/parent-theme/elements/label.overrides
+++ b/themes/src/themes/parent-theme/elements/label.overrides
@@ -74,6 +74,7 @@ a.ui.purple.labels {
   color: @offBlack !important;
 }
 
+/* Can't add new color options to default config - this replaces violet with lighterPurple */
 .ui.violet.label,
 .ui.violet.labels {
   background: @lighterPurple !important;
@@ -82,6 +83,7 @@ a.ui.purple.labels {
   font-weight: lighter !important;
 }
 
+/* Same as above - this replaces olive with lighterGrey */
 .ui.olive.label,
 .ui.olive.labels {
   background: @lighterGrey  !important;

--- a/themes/src/themes/parent-theme/elements/label.overrides
+++ b/themes/src/themes/parent-theme/elements/label.overrides
@@ -73,3 +73,19 @@ a.ui.purple.labels {
 .ui.yellow.labels {
   color: @offBlack !important;
 }
+
+.ui.violet.label,
+.ui.violet.labels {
+  background: @lighterPurple !important;
+  border-color: @lighterPurple !important;
+  color: @offBlack !important;
+  font-weight: lighter !important;
+}
+
+.ui.olive.label,
+.ui.olive.labels {
+  background: @lighterGrey  !important;
+  border-color: @lighterGrey  !important;
+  color: @offBlack !important;
+  font-weight: lighter !important;
+} 

--- a/themes/src/themes/parent-theme/elements/label.variables
+++ b/themes/src/themes/parent-theme/elements/label.variables
@@ -158,6 +158,8 @@
 @brownTextColor: @white;
 @greyTextColor: @white;
 @blackTextColor: @white;
+@lighterGrey: #F5F2FD;
+@lighterPurple: #D2C2F9;
 
 @redHoverTextColor: @white;
 @orangeHoverTextColor: @white;


### PR DESCRIPTION
Adds override colours for `violet` and `olive` in order to use the `lighterPurple`
and `lighterGrey` values.
